### PR TITLE
Allow to set a Client ID for producer/consumer

### DIFF
--- a/src/Factory/AmqQueueFactory.php
+++ b/src/Factory/AmqQueueFactory.php
@@ -26,6 +26,10 @@ class AmqQueueFactory implements FactoryInterface
         $stompClient      = $parentLocator->get('SlmQueueAmq\Service\StompClient');
         $jobPluginManager = $parentLocator->get('SlmQueue\Job\JobPluginManager');
 
+        if (null !== $queueOptions->getClientId()) {
+            $stompClient->clientId = $queueOptions->getClientId();
+        }
+
         return new AmqQueue($stompClient, $queueOptions, $requestedName, $jobPluginManager);
     }
 }

--- a/src/Options/QueueOptions.php
+++ b/src/Options/QueueOptions.php
@@ -15,6 +15,11 @@ class QueueOptions extends AbstractOptions
     protected $destination;
 
     /**
+     * @var string
+     */
+    protected $clientId;
+
+    /**
      * Set the queue destionation
      *
      * @param  string $destination
@@ -33,5 +38,27 @@ class QueueOptions extends AbstractOptions
     public function getDestination()
     {
         return $this->destination;
+    }
+
+    /**
+     * Getter for clientId
+     *
+     * @return string|null
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * Setter for clientId
+     *
+     * @param  string $clientId Value to set
+     * @return self
+     */
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
+        return $this;
     }
 }

--- a/src/Queue/AmqQueue.php
+++ b/src/Queue/AmqQueue.php
@@ -77,6 +77,7 @@ class AmqQueue extends AbstractQueue implements AmqQueueInterface
      */
     public function pop(array $options = array())
     {
+        $options = $this->options->getClientId() ? [self::PERSISTENT => true] : [];
         $this->stompClient->subscribe($this->options->getDestination());
         if (array_key_exists('timeout', $options)) {
             $this->stompClient->setReadTimeout((int) $options['timeout'], 0);

--- a/src/Queue/AmqQueue.php
+++ b/src/Queue/AmqQueue.php
@@ -77,7 +77,7 @@ class AmqQueue extends AbstractQueue implements AmqQueueInterface
      */
     public function pop(array $options = array())
     {
-        $options = $this->options->getClientId() ? [self::PERSISTENT => true] : [];
+        $options += $this->options->getClientId() ? [self::PERSISTENT => true] : [];
         $this->stompClient->subscribe($this->options->getDestination());
         if (array_key_exists('timeout', $options)) {
             $this->stompClient->setReadTimeout((int) $options['timeout'], 0);


### PR DESCRIPTION
When the worker detects a client id is set, make sure the subscription
is started as persistent.
