### PR TITLE
Only subscribe once during worker pop() loop

### DIFF
--- a/src/Queue/AmqQueue.php
+++ b/src/Queue/AmqQueue.php
@@ -78,7 +78,6 @@ class AmqQueue extends AbstractQueue implements AmqQueueInterface
     public function pop(array $options = array())
     {
         $options += $this->options->getClientId() ? [self::PERSISTENT => true] : [];
-        $this->stompClient->subscribe($this->options->getDestination());
         if (array_key_exists('timeout', $options)) {
             $this->stompClient->setReadTimeout((int) $options['timeout'], 0);
         }
@@ -106,5 +105,11 @@ class AmqQueue extends AbstractQueue implements AmqQueueInterface
         if (!$this->stompClient->isConnected()) {
             $this->stompClient->connect();
         }
+    }
+
+    public function subscribe()
+    {
+        // if not subscribed?
+        $this->stompClient->subscribe($this->options->getDestination());
     }
 }

--- a/src/Queue/AmqQueue.php
+++ b/src/Queue/AmqQueue.php
@@ -109,7 +109,11 @@ class AmqQueue extends AbstractQueue implements AmqQueueInterface
 
     public function subscribe()
     {
-        // if not subscribed?
-        $this->stompClient->subscribe($this->options->getDestination());
+        $destination   = $this->options->getDestination();
+        $subscriptions = $this->stompClient->getSubscriptions();
+
+        if (!in_array($destination, $subscriptions)) {
+            $this->stompClient->subscribe($destination);
+        }
     }
 }

--- a/src/Service/StompClient.php
+++ b/src/Service/StompClient.php
@@ -6,5 +6,8 @@ use FuseSource\Stomp\Stomp;
 
 class StompClient extends Stomp implements StompClientInterface
 {
-
+    public function getSubscriptions()
+    {
+        return $this->_subscriptions;
+    }
 }

--- a/src/Service/StompClientInterface.php
+++ b/src/Service/StompClientInterface.php
@@ -4,6 +4,7 @@ namespace SlmQueueAmq\Service;
 
 interface StompClientInterface
 {
+    /* Methods used from the Stomp client implementation */
     public function connect($username = '', $password = '');
     public function isConnected();
     public function send($destination, $message, $properties = [], $sync = null);
@@ -17,4 +18,7 @@ interface StompClientInterface
     public function readFrame();
     public function setReadTimeout($seconds, $milliseconds = 0);
     public function hasFrameToRead();
+
+    /* Custom method */
+    public function getSubscriptions();
 }

--- a/src/Worker/AmqWorker.php
+++ b/src/Worker/AmqWorker.php
@@ -15,6 +15,8 @@ use Zend\EventManager\EventManagerInterface;
  */
 class AmqWorker extends AbstractWorker
 {
+    protected $connected = false;
+
     /**
      * @param EventManagerInterface $eventManager
      */
@@ -61,5 +63,10 @@ class AmqWorker extends AbstractWorker
         }
 
         $queue->ensureConnection();
+
+        if ($this->connected === false) {
+            $queue->subscribe();
+            $this->connected = true;
+        }
     }
 }

--- a/src/Worker/AmqWorker.php
+++ b/src/Worker/AmqWorker.php
@@ -15,8 +15,6 @@ use Zend\EventManager\EventManagerInterface;
  */
 class AmqWorker extends AbstractWorker
 {
-    protected $connected = false;
-
     /**
      * @param EventManagerInterface $eventManager
      */
@@ -63,10 +61,6 @@ class AmqWorker extends AbstractWorker
         }
 
         $queue->ensureConnection();
-
-        if ($this->connected === false) {
-            $queue->subscribe();
-            $this->connected = true;
-        }
+        $queue->subscribe();
     }
 }

--- a/tests/SlmQueueAmqTest/Queue/AmqQueueTest.php
+++ b/tests/SlmQueueAmqTest/Queue/AmqQueueTest.php
@@ -78,21 +78,6 @@ class AmqQueueTest extends TestCase
         $this->queue->pop();
     }
 
-    public function testPopSubscribesToQueueFirst()
-    {
-        $this->options->setDestination('queue/foo');
-
-        $this->stompClient->expects($this->once())
-                          ->method('subscribe')
-                          ->with('queue/foo');
-
-        $this->stompClient->expects($this->once())
-                          ->method('readFrame')
-                          ->will($this->returnValue(false));
-
-        $this->queue->pop();
-    }
-
     public function testPopSetsTimeoutWhenAvailable()
     {
         $this->stompClient->expects($this->once())


### PR DESCRIPTION
Because of the worker loop calls pop() everytime it goes through
one iteration, the AMQ consumers are created once for every iteration.

Now only subscribe to the queue when the loop starts, with a specified
listener and not on every pop() call.

Closes #5 
