### PR TITLE
Experiment with the Stomp PECL extension

### DIFF
--- a/src/Service/StompClient.php
+++ b/src/Service/StompClient.php
@@ -2,12 +2,73 @@
 
 namespace SlmQueueAmq\Service;
 
-use FuseSource\Stomp\Stomp;
+use Stomp;
 
-class StompClient extends Stomp implements StompClientInterface
+class StompClient implements StompClientInterface
 {
+    protected $subscriptions = [];
+    protected $stomp;
+    protected $broker;
+
+    public function __construct($broker)
+    {
+        $this->broker = $broker;
+    }
+
+    public function isConnected()
+    {
+        return (null !== $this->stomp);
+    }
+
+    public function connect($username = '', $password = '')
+    {
+        $this->stomp = new Stomp($this->broker, $username, $password);
+    }
+
+    public function send($destination, $message, $properties = [], $sync = null)
+    {
+        $this->stomp->send($destination, $message, $properties);
+    }
+
+    public function subscribe($destination, $properties = [], $sync = null)
+    {
+        $this->stomp->subscribe($destination, $properties);
+        $this->subscriptions[$destination] = $properties;
+    }
+
     public function getSubscriptions()
     {
-        return $this->_subscriptions;
+        return $this->subscriptions;
+    }
+
+    public function unsubscribe($destination, $properties = [], $sync = null)
+    {
+        $this->stomp->unsubscribe($destination, $properties);
+    }
+
+    public function ack($message, $transactionId = null)
+    {
+        $headers = ($transactionId) ? ['transaction' => $transactionId] : [];
+        $this->stomp->ack($message, $headers);
+    }
+
+    public function disconnect()
+    {
+        unset($this->stomp);
+    }
+
+    public function readFrame()
+    {
+        return $this->stomp->readFrame();
+    }
+
+    public function setReadTimeout($seconds, $milliseconds = 0)
+    {
+        $this->stomp->setReadTimeout($seconds, $milliseconds);
+    }
+
+    public function hasFrameToRead()
+    {
+        return $this->stomp->hasFrame();
     }
 }

--- a/src/Service/StompClientInterface.php
+++ b/src/Service/StompClientInterface.php
@@ -10,9 +10,6 @@ interface StompClientInterface
     public function send($destination, $message, $properties = [], $sync = null);
     public function subscribe($destination, $properties = [], $sync = null);
     public function unsubscribe($destination, $properties = [], $sync = null);
-    public function begin($transactionId = null, $sync = null);
-    public function commit($commit = null, $sync = null);
-    public function abort($transactionId = null, $sync = null);
     public function ack($message, $transactionId = null);
     public function disconnect();
     public function readFrame();


### PR DESCRIPTION
@bgallagher experimented with the PECL, this seems to work. It wasn't that much work after all :)

Transactions are not supported by the PECL extension, so removing those methods from the interface but on the other hand, this is not used in the SlmQueueAmq module as well. The service client class does not inherit the Stomp client anymore, but composes it to give a little bit more flexibility.

The downside of the PECL extension is that it's harder to install and therefore the curve for using SlmQueueAmq is slightly increased. However, it seems that a bridge is quite easy to accomplish so we might even use the Zend ServiceManager to swap the client and having a sort-of adapter pattern with two service bridges.

Setting this as a "long term" but if you want to experiment performance wise with the PECL extension vs stomp-php, just check out this branch.
