### PR TITLE
Move worker listener closure to class

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -35,6 +35,18 @@ return [
     'slm_queue' => [
         'active_mq' => [
             'broker_url' => '',
-        ]
+        ],
+        'worker_strategies' => [
+            'queues' => [
+                'default' => [
+                    'SlmQueueAmq\Strategy\SubscribeStrategy',
+                ],
+            ]
+        ],
+        'strategy_manager' => [
+            'invokables' => [
+                'SlmQueueAmq\Strategy\SubscribeStrategy' => 'SlmQueueAmq\Strategy\SubscribeStrategy',
+            ],
+        ],
     ]
 ];

--- a/src/Strategy/SubscribeStrategy.php
+++ b/src/Strategy/SubscribeStrategy.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SlmQueueAmq\Strategy;
+
+use SlmQueue\Strategy\AbstractStrategy;
+use SlmQueue\Worker\WorkerEvent;
+use SlmQueueAmq\Queue\AmqQueueInterface;
+use SlmQueueAmq\Worker\Exception\InvalidQueueException;
+use Zend\EventManager\EventManagerInterface;
+
+class SubscribeStrategy extends AbstractStrategy
+{
+    protected $state;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(
+            WorkerEvent::EVENT_BOOTSTRAP,
+            array($this, 'connectAndSubscribe'),
+            $priority
+        );
+    }
+
+    /**
+     * Connect and subscribe to the AMQ queue
+     *
+     * @param WorkerEvent $event
+     */
+    public function connectAndSubscribe(WorkerEvent $event)
+    {
+        $queue = $event->getQueue();
+        if (!$queue instanceof AmqQueueInterface) {
+            throw new InvalidQueueException;
+        }
+
+        $queue->ensureConnection();
+        $queue->subscribe();
+    }
+}

--- a/src/Worker/AmqWorker.php
+++ b/src/Worker/AmqWorker.php
@@ -16,16 +16,6 @@ use Zend\EventManager\EventManagerInterface;
 class AmqWorker extends AbstractWorker
 {
     /**
-     * @param EventManagerInterface $eventManager
-     */
-    public function __construct(EventManagerInterface $eventManager)
-    {
-        parent::__construct($eventManager);
-
-        $this->eventManager->attach(WorkerEvent::EVENT_BOOTSTRAP, [$this, 'connect']);
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function processJob(JobInterface $job, QueueInterface $queue)
@@ -48,19 +38,5 @@ class AmqWorker extends AbstractWorker
             // Do nothing, the job will be reinserted automatically for another try
             return WorkerEvent::JOB_STATUS_FAILURE_RECOVERABLE;
         }
-    }
-
-    /**
-     * Connect to the Active MQ server when starting the queue process
-     */
-    public function connect(WorkerEvent $event)
-    {
-        $queue = $event->getQueue();
-        if (!$queue instanceof AmqQueueInterface) {
-            throw new Exception\InvalidQueueException;
-        }
-
-        $queue->ensureConnection();
-        $queue->subscribe();
     }
 }


### PR DESCRIPTION
The closure is, because of a bug in SlmQueue, executed twice. By
moving it to a separate class and list it as a strategy for all
queues, the consumer is only subscribed once.
